### PR TITLE
refac(BackendAPI/src/modules/common/guards/roles.guard): refactorize …

### DIFF
--- a/BackendAPI/src/modules/common/guards/roles.guard.ts
+++ b/BackendAPI/src/modules/common/guards/roles.guard.ts
@@ -21,30 +21,29 @@ export class RolesGuard implements CanActivate {
         ]);
 
 
-        // if (isPublic) return true
+        if (isPublic) return true
+
+        const { user } = context.switchToHttp().getRequest()
+
+        if (!user) throw new ForbiddenException("No tienes autorización para acceder a esta ruta.")
+
+        if (isAdminRoute && user.isAdmin) return true;
 
 
-        // if (isAdminRoute) {
-        //     const { user } = context.switchToHttp().getRequest()
-        //     return user.isAdmin === true
+        if (requiredRoles?.length) {
 
-        // }
+            const hasRole = () => requiredRoles.some((rol) => user?.role?.includes(rol))
+
+            const isValid = user && user.role && hasRole();
+
+            if (!isValid) throw new ForbiddenException("No tienes autorización para acceder a esta ruta.")
+
+            return isValid;
+
+        }
+
+        throw new ForbiddenException("No tienes autorización para acceder a esta ruta.")
 
 
-        // if (!requiredRoles || requiredRoles.length === 0) return true
-
-        // const { user } = context.switchToHttp().getRequest()
-
-        // const hasRole = () => requiredRoles.some((rol) => user?.role?.includes(rol))
-
-        // if (user.isAdmin) return true
-
-        // const isValid = user && user.role && hasRole();
-
-        // if (!isValid) throw new ForbiddenException("No tienes autorización para acceder a esta ruta.")
-
-        // return isValid;
-
-        return true
     }
 }

--- a/BackendAPI/src/modules/users/users.controller.ts
+++ b/BackendAPI/src/modules/users/users.controller.ts
@@ -24,6 +24,7 @@ export class UsersController {
   @ApiInternalServerErrorResponse({ description: 'Error interno del servidor' })
   @ApiBearerAuth()
   @Admin()
+  @Roles(Role.USER, Role.PETSHOP)
   @Get()
   getAllUsers(@Request() req: ExpressRequest & { user: Users }) {
     return this.usersService.getAllUsers()
@@ -34,8 +35,8 @@ export class UsersController {
   @ApiUnauthorizedResponse({ description: 'No autorizado' })
   @ApiInternalServerErrorResponse({ description: 'Error interno del servidor' })
   @Roles(Role.USER, Role.PETSHOP)
-  @ApiBearerAuth()
   @Admin()
+  @ApiBearerAuth()
   @Get(':id')
   getUserById(@Param('id', ParseUUIDPipe) id: string, @Request() req: ExpressRequest & { user: Users }) {
     return this.usersService.getUserById(id);


### PR DESCRIPTION
…the roles.guard to let access to each route according to the role without regarding of Admin decorator

Now every user should be able to access a specific route, according to the role required for each route, regardless of whether the route has and @Admin() decorator or not