### PR TITLE
fix(BackendAPI/src/modules/calendly): Replace JwtGuard with ApiBearer…

### DIFF
--- a/BackendAPI/src/modules/calendly/calendly.controller.ts
+++ b/BackendAPI/src/modules/calendly/calendly.controller.ts
@@ -1,14 +1,14 @@
 import { Controller, Get, Query, UseGuards, HttpException, HttpStatus } from '@nestjs/common';
-import { JwtAuthGuard } from '../common/guards/auth.guard';
 import { ValidationPipe } from '@nestjs/common'; 
 import { CalendlyApiService } from './clanedly.service';
 import { ListEventsQueryDto } from './dto/list-events-query.dto';
+import { ApiBearerAuth } from '@nestjs/swagger';
 
 @Controller('calendly')
 export class CalendlyController {
   constructor(private readonly calendlyApiService: CalendlyApiService) {}
   
-  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @Get('events')
   async getCalendlyEvents(
     @Query(new ValidationPipe({ transform: true })) query: ListEventsQueryDto, 

--- a/BackendAPI/src/modules/calendly/calendly.module.ts
+++ b/BackendAPI/src/modules/calendly/calendly.module.ts
@@ -4,10 +4,12 @@ import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Users } from '../users/entity/users.entity'; 
 import { CalendlyApiService } from './clanedly.service';
+import { JwtGuard } from '../common/guards/jwt.auth.guard';
+import { JwtGuardStrategy } from '../common/strategies/jwt.auth.strategy';
 
 @Module({
   imports: [ConfigModule, TypeOrmModule.forFeature([Users])], 
-  providers: [CalendlyApiService],
+  providers: [CalendlyApiService, JwtGuard, JwtGuardStrategy],
   controllers: [CalendlyController],
   exports: [CalendlyApiService],
 })


### PR DESCRIPTION
Added To Calendly Module

JwtGuard, JwtGuardStrategy

Fix inside Calendly Controller

Replace UseGuards decorator with ApiBearerAuthGuard decorator